### PR TITLE
Update egg-limbo.json

### DIFF
--- a/game_eggs/minecraft/java/limbo/egg-limbo.json
+++ b/game_eggs/minecraft/java/limbo/egg-limbo.json
@@ -10,7 +10,8 @@
     "description": "Standalone server program Limbo.",
     "features": null,
     "docker_images": {
-        "ghcr.io\/pterodactyl\/yolks:java_17": "ghcr.io\/pterodactyl\/yolks:java_17"
+        "Java 17": "ghcr.io\/pterodactyl\/yolks:java_17",
+        "Java 21": "ghcr.io\/pterodactyl\/yolks:java_21"
     },
     "file_denylist": [],
     "startup": "java -Xms128M -XX:MaxRAMPercentage=95.0 -jar {{SERVER_JARFILE}}",


### PR DESCRIPTION
- Fixed where the Java 17 egg said the entire Egg path as the name instead of just "Java 17.

- Added Java 21 Docker Support
