### PR TITLE
Include `dotnet_8` image for `egg-t-modloader`

### DIFF
--- a/game_eggs/terraria/tmodloader/egg-t-modloader.json
+++ b/game_eggs/terraria/tmodloader/egg-t-modloader.json
@@ -10,6 +10,7 @@
     "description": "tModLoader is essentially a mod that provides a way to load your own mods without having to work directly with Terraria's source code itself. This means you can easily make mods that are compatible with other people's mods, save yourself the trouble of having to decompile and recompile Terraria.exe, and escape from having to understand all of the obscure \"intricacies\" of Terraria's source code. It is made to work for Terraria 1.3+.",
     "features": null,
     "docker_images": {
+        "Dotnet 8": "ghcr.io\/parkervcp\/yolks:dotnet_8",
         "Dotnet 6": "ghcr.io\/parkervcp\/yolks:dotnet_6"
     },
     "file_denylist": [],


### PR DESCRIPTION
This will fix the "You must install or upgrade .NET to run this application" issue with newer tModLoader.

I discovered that someone had already reported it (https://github.com/pelican-eggs/eggs/issues/2910), but decided to leave the rest in the dark, but with his "update the yolk" clue, I was able to figure it out myself.

# Description

## Checklist for all submissions

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?

* [x] The egg was edited here in GitHub