### PR TITLE
Remove ` --disable-ansi` flag from PMMP egg

### DIFF
--- a/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
+++ b/game_eggs/minecraft/bedrock/pocketmine_mp/egg-pocketmine-m-p.json
@@ -13,7 +13,7 @@
         "ghcr.io\/parkervcp\/yolks:debian": "ghcr.io\/parkervcp\/yolks:debian"
     },
     "file_denylist": [],
-    "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard --disable-ansi",
+    "startup": ".\/bin\/php7\/bin\/php .\/PocketMine-MP.phar --no-wizard",
     "config": {
         "files": "{\r\n    \"server.properties\": {\r\n        \"parser\": \"properties\",\r\n        \"find\": {\r\n            \"server-ip\": \"0.0.0.0\",\r\n            \"enable-query\": \"true\",\r\n            \"server-port\": \"{{server.build.default.port}}\",\r\n            \"query.port\": \"{{server.build.default.port}}\"\r\n        }\r\n    }\r\n}",
         "startup": "{\r\n    \"done\": \")! \"\r\n}",


### PR DESCRIPTION
# Description

PocketMine-MP can detect whether the system has support for using ansi. There is no need to leave this flag at startup by default.