### PR TITLE
Changed Start Configuration

### DIFF
--- a/game_eggs/steamcmd_servers/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
+++ b/game_eggs/steamcmd_servers/valheim/valheim_bepinex/egg-valheim-bep-i-nex.json
@@ -4,7 +4,7 @@
         "version": "PTDL_v2",
         "update_url": null
     },
-    "exported_at": "2024-03-20T08:48:44+01:00",
+    "exported_at": "2024-05-08T11:12:09-05:00",
     "name": "Valheim  BepINex",
     "author": "eggs@goover.dev",
     "description": "A brutal exploration and survival game for 1-10 players, set in a procedurally-generated purgatory inspired by viking culture incl the Plugin Framework BepInEx",
@@ -18,7 +18,7 @@
     "startup": "export DOORSTOP_ENABLE=TRUE; export DOORSTOP_INVOKE_DLL_PATH=.\/BepInEx\/core\/BepInEx.Preloader.dll; export LD_LIBRARY_PATH=\".\/doorstop_libs:$LD_LIBRARY_PATH\"; export LD_PRELOAD=\"libdoorstop_x64.so:$LD_PRELOAD\"; export templdpath=$LD_LIBRARY_PATH; export LD_LIBRARY_PATH=\".\/linux64:$LD_LIBRARY_PATH\"; export SteamAppId=892970; export LD_LIBRARY_PATH=$templdpath; .\/valheim_server.x86_64 -nographics -batchmode -name \"{{SERVER_NAME}}\" -port {{SERVER_PORT}} -world \"{{WORLD}}\" -password \"{{PASSWORD}}\" -public {{PUBLIC_SERVER}} -saveinterval {{BACKUP_INTERVAL}} -backups {{BACKUP_COUNT}} -backupshort {{BACKUP_SHORTTIME}} -backuplong {{BACKUP_LONGTIME}} $( [[ {{ENABLE_CROSSPLAY}} -eq 1 ]] && echo \" -crossplay \") > >(sed -uE \"{{CONSOLE_FILTER}}\") & trap \"{{STOP}}\" 15; wait $!",
     "config": {
         "files": "{}",
-        "startup": "{\r\n    \"done\": \"DungeonDB Start\"\r\n}",
+        "startup": "{\r\n    \"done\": \"Game server connected\"\r\n}",
         "logs": "{}",
         "stop": "^C"
     },


### PR DESCRIPTION
Changed Start Configuration to more accurate represent when the server is ready for client connections.

old was "DungeonDB Start" but clients are not actually able to connect until the server says "Game server connected"

# Description

<!-- Please explain what is being changed or added as a short overview for this PR. Also, link existing relevant issues if they exist with resolves # -->

## Checklist for all submissions

<!-- insert X into the brackets to mark it as done (i.e. [x]). You can click preview to make the links appear clickable. -->

* [x] Have you followed the guidelines in our [Contributing document](https://github.com/parkervcp/eggs/blob/master/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../pulls) for the same update/change?
* [x] Have you tested and reviewed your changes with confidence that everything works?
* [x] Did you branch your changes and PR from that branch and not from your master branch?
  * If not, why?:

<!-- If this is an egg update fill these out -->

* [x] You verify that the start command applied does not use a shell script
  * [x] If some script is needed then it is part of a current yolk or a PR to add one
* [x] The egg was exported from the panel

<!-- You can erase the new egg submission template if you're not adding a completely new egg -->

## New egg Submissions

1. [x] Does your submission pass tests (server is connectable)?
2. [ ] Does your egg use a custom docker image?
    * [ ] Have you tried to use a generic image?
    * [ ] Did you PR the necessary changes to make it work?
3. [ ] Have you added the egg to the main README.md and any other README files in subdirectories of the egg (e.g /game_eggs) according to the alphabetical order?
4. [ ] Have you added a unique README.md for the egg you are adding according to the alphabetical order?
5. [ ] You verify that the start command applied does not use a shell script
    * [ ] If some script is needed then it is part of a current yolk or a PR to add one
6. [x] The egg was exported from the panel